### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,11 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson): DataProvider => ({
 
     getMany: (resource, params) => {
         const url = `${apiUrl}/records/${resource}/${params.ids.join(',')}`;
-        return httpClient(url).then(({ json }) => ({ data: json }));
+        if (params.ids.length === 1) {
+            return httpClient(url).then(({ json }) => ({ data: [json] })); // needs to be an array even if one id is passed
+        } else {
+            return httpClient(url).then(({ json }) => ({ data: json }));
+        }
     },
 
     // TODO: filter is not well-formed


### PR DESCRIPTION
response format for `getMany` is `{ data: {Record[]}, validUntil?: {Date} }`
react-admin at times queries `getMany` with only one id, if so [https://github.com/mevdschee/php-crud-api](url) returns the single record; not an array with one record

`getMany` must always return an array, even if it contains only one record

not sure if this is the best way but I'm still learning